### PR TITLE
Smooth transition from landing to index

### DIFF
--- a/final-landing-animated.html
+++ b/final-landing-animated.html
@@ -42,6 +42,11 @@
             -webkit-transform: translateZ(0);
             will-change: transform;
         }
+
+        body.fade-out {
+            opacity: 0;
+            transition: opacity 0.8s ease;
+        }
         
         #ascii-container {
             position: fixed;
@@ -755,6 +760,13 @@
             overlay.classList.remove('active');
             document.getElementById('emailForm').reset();
         }
+
+        function transitionToIndex() {
+            document.body.classList.add('fade-out');
+            setTimeout(() => {
+                window.location.href = 'index.html';
+            }, 800);
+        }
         
         function handleEmailSubmit(event) {
             event.preventDefault();
@@ -790,15 +802,14 @@
             
             setTimeout(() => {
                 localStorage.setItem('ci_network_email', email);
-                
+
                 submitButton.textContent = 'Link Established';
                 submitButton.style.background = 'linear-gradient(135deg, rgba(34, 197, 94, 0.3), rgba(22, 163, 74, 0.4))';
-                
+
                 setTimeout(() => {
-                    alert(`Welcome to the Collective Intelligence Network, ${email}. Access granted.`);
-                    hideEmailForm();
+                    transitionToIndex();
                 }, 1000);
-                
+
             }, 1500);
         }
         

--- a/index.html
+++ b/index.html
@@ -1523,6 +1523,11 @@
         body[data-view="dream"] {
             --current-accent-rgb: 139, 92, 246; /* purple */
         }
+
+        body {
+            opacity: 0;
+            transition: opacity 0.8s ease;
+        }
     </style>
 </head>
 <body class="bg-deep-void text-text-primary font-mono font-extralight">
@@ -3514,6 +3519,7 @@
 
         // Enhanced Main Application
         document.addEventListener('DOMContentLoaded', () => {
+            document.body.style.opacity = '1';
             // Initialize systems
             const authManager = new AuthenticationManager();
             const searchEngine = new SearchEngine();


### PR DESCRIPTION
## Summary
- animate body fade-out when transitioning from landing page
- after email submission, navigate to `index.html` with a smooth fade effect
- fade `index.html` in on page load for a seamless transition

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6859c7a4af80832297ee7696bd8ce289